### PR TITLE
Modify permissions of /tmp to make auto start running correctly.

### DIFF
--- a/scripts/auto_start/rm_can_start.sh
+++ b/scripts/auto_start/rm_can_start.sh
@@ -13,4 +13,5 @@ if [[ $HAS_SWITCH == has ]]; then
 else
   export ROS_IP=127.0.0.1
 fi
+sudo chmod -t /tmp
 mon launch --disable-ui rm_bringup $LAUNCH.launch

--- a/scripts/auto_start/rm_ecat_start.sh
+++ b/scripts/auto_start/rm_ecat_start.sh
@@ -8,4 +8,5 @@ if [[ $HAS_SWITCH == has ]]; then
 else
   export ROS_IP=127.0.0.1
 fi
+sudo chmod -t /tmp
 mon launch --disable-ui rm_bringup $LAUNCH.launch

--- a/scripts/auto_start/vision_start.sh
+++ b/scripts/auto_start/vision_start.sh
@@ -8,4 +8,5 @@ if [[ $HAS_SWITCH == has ]]; then
 else
   export ROS_IP=127.0.0.1
 fi
+sudo chmod -t /tmp
 mon launch --disable-ui rm_bringup vision_start.launch


### PR DESCRIPTION
修改了/tmp文件夹的权限，解决了ethercat有时由于权限无法正常地跑起来的问题。